### PR TITLE
fix the following markdownlint issues

### DIFF
--- a/pkg/document/template.go
+++ b/pkg/document/template.go
@@ -46,7 +46,7 @@ func getImageTemplate() string {
 
 	templateBuilder.WriteString(`{{ define "cook.imageSection" }}`)
 	templateBuilder.WriteString("{{ if .Metadata.ImageName }}")
-	templateBuilder.WriteString(`![](../assets/images/{{ lower .Metadata.ImageName | replace " " "-" }})`)
+	templateBuilder.WriteString(`![{{ .Metadata.title }}](../assets/images/{{ lower .Metadata.ImageName | replace " " "-" }})`)
 	templateBuilder.WriteString("{{ end }}")
 	templateBuilder.WriteString("{{ end }}")
 
@@ -82,7 +82,7 @@ func getIngredientsTemplate() string {
 	templateBuilder.WriteString("{{ range .Steps }}")
 	templateBuilder.WriteString("{{- range .Ingredients }}")
 	templateBuilder.WriteString("\n")
-	templateBuilder.WriteString("- {{ if .Amount.Quantity }}{{ round .Amount.Quantity 2 }} {{ .Amount.Unit }}{{ else }}some{{ end }}")
+	templateBuilder.WriteString("- {{ if .Amount.Quantity }}{{ round .Amount.Quantity 2 }}{{ if .Amount.Unit }} {{ .Amount.Unit }}{{ end }}{{ else }}some{{ end }}")
 	templateBuilder.WriteString(" {{ .Name }}")
 	templateBuilder.WriteString("{{- end }}")
 	templateBuilder.WriteString("{{- end }}")
@@ -194,13 +194,13 @@ func getSourceTemplate() string {
 	templateBuilder.WriteString("{{ end }}")
 
 	templateBuilder.WriteString(`{{ define "cook.source" }}`)
-	templateBuilder.WriteString("- {{ .Metadata.source }}")
+	templateBuilder.WriteString("- <{{ .Metadata.source }}>")
 	templateBuilder.WriteString("{{ end }}")
 
 	templateBuilder.WriteString(`{{ define "cook.sourceSection" }}`)
 	templateBuilder.WriteString("{{ if .Metadata.source }}")
 	templateBuilder.WriteString(`{{ template "cook.sourceHeader" . }}`)
-	templateBuilder.WriteString("\n")
+	templateBuilder.WriteString("\n\n")
 	templateBuilder.WriteString(`{{ template "cook.source" . }}`)
 	templateBuilder.WriteString("{{ end }}")
 	templateBuilder.WriteString("{{ end }}")


### PR DESCRIPTION
Fix the following markdownlint issues
- [MD045 no-alt-text](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md045---images-should-have-alternate-text-alt-text)
- [MD034 no-bare-urls](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md034---bare-url-used)
- [MD022 blanks-around-headings](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md022---headings-should-be-surrounded-by-blank-lines)

fix additional space in ingredient when no unit is specified.