### PR TITLE
Use native lazy loading by default

### DIFF
--- a/cmd/cook-docs/testdata/recipe.md.gotmpl
+++ b/cmd/cook-docs/testdata/recipe.md.gotmpl
@@ -1,6 +1,6 @@
 {{ template "cook.headerSection" . }}
 
-{{ template "cook.imageSection" . }}
+{{ template "cook.lazyImageSection" . }}
 
 {{ template "cook.tableSection" . }}
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -13,7 +13,7 @@ this:
 ```go title="recipe.md.gotmpl"
 {{ template "cook.headerSection" . }}
 
-{{ template "cook.imageSection" . }}
+{{ template "cook.lazyImageSection" . }}
 
 {{ template "cook.tableSection" . }}
 

--- a/pkg/document/template.go
+++ b/pkg/document/template.go
@@ -19,7 +19,7 @@ import (
 
 const defaultDocumentationTemplate = `{{ template "cook.headerSection" . }}
 
-{{ template "cook.imageSection" . }}
+{{ template "cook.lazyImageSection" . }}
 
 {{ template "cook.tableSection" . }}
 
@@ -48,6 +48,18 @@ func getImageTemplate() string {
 	templateBuilder.WriteString(`{{ define "cook.imageSection" }}`)
 	templateBuilder.WriteString("{{ if .Info.ImageFileName }}")
 	templateBuilder.WriteString(`![{{ .Info.RecipeName }}](../assets/images/{{ lower .Info.ImageFileName | replace " " "-" }})`)
+	templateBuilder.WriteString("{{ end }}")
+	templateBuilder.WriteString("{{ end }}")
+
+	return templateBuilder.String()
+}
+
+func getLazyImageTemplate() string {
+	templateBuilder := strings.Builder{}
+
+	templateBuilder.WriteString(`{{ define "cook.lazyImageSection" }}`)
+	templateBuilder.WriteString("{{ if .Info.ImageFileName }}")
+	templateBuilder.WriteString(`![{{ .Info.RecipeName }}](../assets/images/{{ lower .Info.ImageFileName | replace " " "-" }}){ loading=lazy }`)
 	templateBuilder.WriteString("{{ end }}")
 	templateBuilder.WriteString("{{ end }}")
 
@@ -306,6 +318,7 @@ func getDocumentationTemplates(recipeSearchRoot string, recipePath string, templ
 	return []string{
 		getHeaderTemplate(),
 		getImageTemplate(),
+		getLazyImageTemplate(),
 		getTableTemplate(),
 		getIngredientsTemplate(),
 		getCookwareTemplate(),


### PR DESCRIPTION
Uses the [`loading="lazy"`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/loading) that is [available](https://caniuse.com/loading-lazy-attr) on every modern browser. The only requirement is [`attr_list`](https://python-markdown.github.io/extensions/attr_list/):
```yml title="mkdocs.yml"
markdown_extensions:
  - attr_list
```

This PR leaves the old `cook.imageSection` alone (for non breaking change), but adds in `cook.lazyImageSection` in addition to it, and sets it as the default for those that don't manually specify in the `.gotmpl`